### PR TITLE
Filter apps for app drawer only after mApps is completely populated.

### DIFF
--- a/src/com/android/launcher3/AppsCustomizePagedView.java
+++ b/src/com/android/launcher3/AppsCustomizePagedView.java
@@ -1686,12 +1686,11 @@ public class AppsCustomizePagedView extends PagedViewWithDraggableItems implemen
                 removePreInstallApps();
             }
 
-            filterAppsWithoutInvalidate();
-
             if (mPreInstallConfig) {
                 addPreInstallApps();
             }
 
+            filterAppsWithoutInvalidate();
             sortByCustomization();
             updatePageCountsAndInvalidateData();
         }
@@ -1754,12 +1753,12 @@ public class AppsCustomizePagedView extends PagedViewWithDraggableItems implemen
             }
 
             addAppsWithoutInvalidate(list);
-            filterAppsWithoutInvalidate();
 
             if (mPreInstallConfig) {
                 addPreInstallApps();
             }
 
+            filterAppsWithoutInvalidate();
             updatePageCountsAndInvalidateData();
         }
     }
@@ -1820,10 +1819,10 @@ public class AppsCustomizePagedView extends PagedViewWithDraggableItems implemen
             }
 
             addAppsWithoutInvalidate(list);
-            filterAppsWithoutInvalidate();
             if (mPreInstallConfig) {
                 addPreInstallApps();
             }
+            filterAppsWithoutInvalidate();
             updatePageCountsAndInvalidateData();
         }
     }


### PR DESCRIPTION
If mPreInstallConfig is set to true, apps will be added to mApps for display
in the drawer after mFilteredApps is filtered from mApps. This results
in applications being hidden from view that should not be.

Filter mApps into mFilteredApps only after addPreInstallApps has been called.

Change-Id: Ic426c5e530ffa61e0cbca211a6a32fcba38fc08b