### PR TITLE
Fix potential NPE handling TransitionEffectsFragment

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -275,7 +275,6 @@ public class Launcher extends Activity
     private DragLayer mDragLayer;
     private DragController mDragController;
     private View mWeightWatcher;
-    private TransitionEffectsFragment mTransitionEffectsFragment;
     private DynamicGridSizeFragment mDynamicGridSizeFragment;
     private LauncherClings mLauncherClings;
     protected HiddenFolderFragment mHiddenFolderFragment;
@@ -1156,12 +1155,13 @@ public class Launcher extends Activity
         PackageInstallerCompat.getInstance(this).onResume();
 
         //Close out Fragments
-        Fragment f = getFragmentManager().findFragmentByTag(
-                TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
-        if (f != null) {
-            mTransitionEffectsFragment.setEffect();
+        TransitionEffectsFragment tef =
+                (TransitionEffectsFragment)getFragmentManager().findFragmentByTag(
+                        TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
+        if (tef != null) {
+            tef.setEffect();
         }
-        f = getFragmentManager().findFragmentByTag(
+        Fragment f = getFragmentManager().findFragmentByTag(
                 DynamicGridSizeFragment.DYNAMIC_GRID_SIZE_FRAGMENT);
         if (f != null) {
             mDynamicGridSizeFragment.setSize();
@@ -1325,10 +1325,10 @@ public class Launcher extends Activity
         FragmentManager fragmentManager = getFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 
-        mTransitionEffectsFragment = new TransitionEffectsFragment();
-        mTransitionEffectsFragment.setArguments(bundle);
+        TransitionEffectsFragment tef = new TransitionEffectsFragment();
+        tef.setArguments(bundle);
         fragmentTransaction.setCustomAnimations(0, 0);
-        fragmentTransaction.replace(R.id.launcher, mTransitionEffectsFragment,
+        fragmentTransaction.replace(R.id.launcher, tef,
                 TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
         fragmentTransaction.commit();
     }
@@ -1357,9 +1357,10 @@ public class Launcher extends Activity
             fragmentTransaction
                     .setCustomAnimations(0, R.anim.exit_out_right);
         }
+        Fragment f = getFragmentManager().findFragmentByTag(
+                TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
         fragmentTransaction
-                .remove(mTransitionEffectsFragment).commit();
-        mTransitionEffectsFragment = null;
+                .remove(f).commit();
 
         mDarkPanel.setVisibility(View.VISIBLE);
         ObjectAnimator anim = ObjectAnimator.ofFloat(
@@ -2716,12 +2717,13 @@ public class Launcher extends Activity
                 showOverviewMode(true);
             }
         } else if (mWorkspace.isInOverviewMode()) {
-            Fragment f = getFragmentManager().findFragmentByTag(
-                    TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
+            TransitionEffectsFragment tef =
+                    (TransitionEffectsFragment)getFragmentManager().findFragmentByTag(
+                            TransitionEffectsFragment.TRANSITION_EFFECTS_FRAGMENT);
             Fragment f2 = getFragmentManager().findFragmentByTag(
                     DynamicGridSizeFragment.DYNAMIC_GRID_SIZE_FRAGMENT);
-            if (f != null) {
-                mTransitionEffectsFragment.setEffect();
+            if (tef != null) {
+                tef.setEffect();
             } else if (f2 != null) {
                 mDynamicGridSizeFragment.setSize();
             } else {


### PR DESCRIPTION
Instead of holding a reference to transition effects fragment and
attempting to keep it in sync with what the fragment manager holds,
just get the fragment from the manager each time.

Change-Id: Ifd92725c1731cc6677d6d2a06226e070fbc093e3